### PR TITLE
Feat: #57 Added stats based attacks

### DIFF
--- a/__tests__/utils/fakeData.json
+++ b/__tests__/utils/fakeData.json
@@ -25,6 +25,16 @@
       "phase": 2,
       "start": "2024-03-10T14:46:20.986Z",
       "finish": "2024-03-10T14:53:25.923Z"
+    },
+    {
+      "_id": "65edc7bcefd4ecbb6ca8d692",
+      "log": "65edc7bcefd4ecbb6ca8d696",
+      "states": "65edc7bcefd4ecbb6ca8d693",
+      "attacker": "65edaf46f08f4b4b8030ff38",
+      "active": true,
+      "phase": 2,
+      "start": "2024-03-10T14:46:20.986Z",
+      "finish": "2024-03-10T14:53:25.923Z"
     }
   ],
   "logs": [
@@ -76,6 +86,41 @@
           }
         ]
       }
+    },
+    {
+      "_id": "65edc7bcefd4ecbb6ca8d693",
+      "initialized": {
+        "attacker": [
+          {
+            "character": "65ed8d7746df2cc0f50926ab",
+            "stats": "65edc7bcefd4ecbb6ca8d672",
+            "hp": 10
+          }
+        ],
+        "enemy": [
+          {
+            "character": "65edaf46f08f4b4b8030ff38",
+            "stats": "65edc7bcefd4ecbb6ca8d671",
+            "hp": 10
+          }
+        ]
+      },
+      "current": {
+        "attacker": [
+          {
+            "character": "65ed8d7746df2cc0f50926ab",
+            "stats": "65edc7bcefd4ecbb6ca8d671",
+            "hp": 8
+          }
+        ],
+        "enemy": [
+          {
+            "character": "65edaf46f08f4b4b8030ff38",
+            "stats": "65edc7bcefd4ecbb6ca8d672",
+            "hp": 5
+          }
+        ]
+      }
     }
   ],
   "stats": [
@@ -93,8 +138,18 @@
       "character": "65edaf46f08f4b4b8030ff38",
       "lvl": 1,
       "stats": {
-        "intelligence": 1,
-        "strength": 1
+        "intelligence": 2,
+        "strength": 2
+      }
+    },
+
+    {
+      "_id": "65edc7bcefd4ecbb6ca8d673",
+      "character": "65edaf46f08f4b4b8030ff39",
+      "lvl": 3,
+      "stats": {
+        "intelligence": 2,
+        "strength": 3
       }
     }
   ]

--- a/src/modules/fights/attack/index.ts
+++ b/src/modules/fights/attack/index.ts
@@ -37,8 +37,6 @@ export default class Controller extends ControllerFactory<EModules.Fights> {
     this._stats = new StatsController();
   }
 
-  // serv -> busin lg->repo   -controler
-  // repo -> db    ---roostert
   private get states(): StatesController {
     return this._states;
   }
@@ -159,9 +157,6 @@ export default class Controller extends ControllerFactory<EModules.Fights> {
     if (attackerStr > targetStr) {
       mod += attackerStr - targetStr;
     }
-    if (mod === 0) {
-      mod = 0;
-    }
     if (mod > 0) {
       mod *= itemPower;
     }
@@ -212,6 +207,7 @@ export default class Controller extends ControllerFactory<EModules.Fights> {
       });
     });
   }
+
   private async initializeFight(userId: string): Promise<IFullFight> {
     const dbFight = await this.rooster.getActiveByUser(userId);
     if (!dbFight) throw new UserNotInFight();

--- a/src/modules/fights/attack/types.d.ts
+++ b/src/modules/fights/attack/types.d.ts
@@ -1,3 +1,7 @@
 export interface IAttackDto {
   target: string;
 }
+
+export interface IBaseDamage {
+  dmg: number;
+}


### PR DESCRIPTION
Changes made to fights/attack include:
- created base methods to calculate attack modifiers, melee damage, apply damage
- created simple loop for team of enemies to perform attack on a single player
- extracted initiliazing fight if no fight was found to seperate method Added IBaseDamage interface with single field dmg.